### PR TITLE
fix:client_max_body_sizeを10Mに設定

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -13,6 +13,7 @@ http {
         server_name itetenosuke.com;
         charset utf-8;
         server_tokens off;
+        client_max_body_size 10M;
 
         location / {
             proxy_pass http://web:8080;


### PR DESCRIPTION
画像サイズによってnginxで弾かれるのを修正。（10Mまで許容する）